### PR TITLE
feat: implement a paginate in reverse flag

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -109,6 +109,7 @@ COMMON_HEADERS_NOGEN := $(COMMON_SRC_NOGEN:.c=.h)	\
 	common/htlc.h					\
 	common/json_command.h				\
 	common/jsonrpc_errors.h				\
+       common/jsonrpc_paginator.h                      \
 	common/overflows.h
 
 COMMON_HEADERS_GEN := common/htlc_state_names_gen.h common/status_wiregen.h common/peer_status_wiregen.h common/scb_wiregen.h

--- a/common/json_param.c
+++ b/common/json_param.c
@@ -1107,8 +1107,9 @@ struct command_result *param_paginator(struct command *cmd, const char *name,
 				       const char *buffer, const jsmntok_t *tok,
 				       struct jsonrpc_paginator **paginator)
 {
-	const jsmntok_t *batch_tok, *offset_tok, *limit_tok;
+	const jsmntok_t *batch_tok, *offset_tok, *limit_tok, *reverse_tok;
 	u64 *limit, *offset;
+	bool *reverse;
 	const char **batch;
 
 	batch = NULL;
@@ -1126,8 +1127,13 @@ struct command_result *param_paginator(struct command *cmd, const char *name,
 	if (limit_tok)
 		json_to_u64(buffer, limit_tok, limit);
 
+	reverse = tal(cmd, bool);
+	reverse_tok = json_get_member(buffer, tok, "reverse");
+	if (reverse_tok)
+		json_to_bool(buffer, reverse_tok, reverse);
+
 	if (batch || (limit && offset)) {
-		*paginator = new_paginator(cmd, batch, limit, offset);
+		*paginator = new_paginator(cmd, batch, limit, offset, reverse);
 		assert(paginator);
 		return NULL;
 	}

--- a/common/json_param.h
+++ b/common/json_param.h
@@ -2,9 +2,11 @@
 #ifndef LIGHTNING_COMMON_JSON_PARAM_H
 #define LIGHTNING_COMMON_JSON_PARAM_H
 #include "config.h"
+#include <assert.h>
 #include <ccan/short_types/short_types.h>
 #include <common/bolt11.h>
 #include <common/json_parse.h>
+#include <common/jsonrpc_paginator.h>
 #include <common/lease_rates.h>
 #include <common/node_id.h>
 #include <common/sphinx.h>
@@ -49,6 +51,10 @@ struct command_result;
 bool param(struct command *cmd, const char *buffer,
 	   const jsmntok_t params[], ...) LAST_ARG_NULL;
 
+bool param_partial_par(struct command *cmd, const char *buffer,
+		       const jsmntok_t tokens[], ...) LAST_ARG_NULL;
+
+
 /*
  * The callback signature.
  *
@@ -79,6 +85,10 @@ enum param_style {
 	PARAM_OPTIONAL,
 	PARAM_OPTIONAL_WITH_DEFAULT,
 };
+
+/** Check if this is a valid paginator input */
+struct command_result *param_paginator(struct command *cmd, const char *name,
+				       const char *buffer, const jsmntok_t *tok);
 
 /*
  * Add a required parameter.
@@ -139,6 +149,9 @@ enum param_style {
 /* Special flag for 'check' which allows any parameters. */
 #define p_opt_any() "", PARAM_OPTIONAL, NULL, NULL
 
+#define p_paginator() "paginator", PARAM_OPTIONAL, param_paginator, NULL
+
+
 /* All the helper routines. */
 struct amount_msat;
 struct amount_sat;
@@ -180,6 +193,11 @@ struct command_result *param_escaped_string(struct command *cmd,
 struct command_result *param_string(struct command *cmd, const char *name,
 				    const char * buffer, const jsmntok_t *tok,
 				    const char **str);
+
+/* Extract an array of strings */
+struct command_result *param_arr_str(struct command *cmd, const char *name,
+				   const char *buffer, const jsmntok_t *tok,
+				   const char ***arr);
 
 /* Extract a label. It is either an escaped string or a number. */
 struct command_result *param_label(struct command *cmd, const char *name,
@@ -340,5 +358,4 @@ struct command_result *param_lease_hex(struct command *cmd,
 struct command_result *param_pubkey(struct command *cmd, const char *name,
 				    const char *buffer, const jsmntok_t *tok,
 				    struct pubkey **pubkey);
-
 #endif /* LIGHTNING_COMMON_JSON_PARAM_H */

--- a/common/json_param.h
+++ b/common/json_param.h
@@ -88,7 +88,8 @@ enum param_style {
 
 /** Check if this is a valid paginator input */
 struct command_result *param_paginator(struct command *cmd, const char *name,
-				       const char *buffer, const jsmntok_t *tok);
+				       const char *buffer, const jsmntok_t *tok,
+	                               struct jsonrpc_paginator **paginator);
 
 /*
  * Add a required parameter.
@@ -149,7 +150,16 @@ struct command_result *param_paginator(struct command *cmd, const char *name,
 /* Special flag for 'check' which allows any parameters. */
 #define p_opt_any() "", PARAM_OPTIONAL, NULL, NULL
 
-#define p_paginator() "paginator", PARAM_OPTIONAL, param_paginator, NULL
+#define p_paginator(arg)                                           \
+	            "paginator",				   \
+	            PARAM_OPTIONAL,				   \
+		    (param_cbx)(param_paginator),                  \
+	            ({ *arg = NULL;			           \
+		    (arg) + 0*sizeof((param_paginator)((struct command *)NULL, \
+		                  (const char *)NULL,              \
+				  (const char *)NULL,              \
+				  (const jsmntok_t *)NULL,         \
+				  (arg)) == (struct command_result *)NULL); })
 
 
 /* All the helper routines. */

--- a/common/json_parse.c
+++ b/common/json_parse.c
@@ -711,3 +711,28 @@ json_tok_channel_id(const char *buffer, const jsmntok_t *tok,
 	return hex_decode(buffer + tok->start, tok->end - tok->start,
 			  cid, sizeof(*cid));
 }
+
+bool json_to_strarr(const tal_t *ctx, const char *buffer,
+		     const jsmntok_t *tok, const char ***arr)
+{
+	const jsmntok_t *curr;
+	size_t i;
+
+	if (tok->type != JSMN_ARRAY)
+		return false;
+
+	*arr = tal_arr(ctx, const char *, 0);
+	json_for_each_arr(i, curr, tok) {
+		struct json_escape *esc;
+		const char *str;
+
+		if (curr->type != JSMN_STRING)
+			return false;
+		esc = json_escape_string_(ctx, buffer + curr->start,
+			   curr->end - curr->start);
+		str = json_escape_unescape(ctx, esc);
+		tal_arr_expand(arr, str);
+	}
+
+	return NULL;
+}

--- a/common/json_parse.h
+++ b/common/json_parse.h
@@ -124,6 +124,9 @@ json_to_blinded_path(const tal_t *ctx, const char *buffer, const jsmntok_t *tok)
 bool json_tok_channel_id(const char *buffer, const jsmntok_t *tok,
 			 struct channel_id *cid);
 
+bool json_to_strarr(const tal_t *ctx, const char *buffer,
+		     const jsmntok_t *tok, const char ***arr);
+
 /* Guide is % for a token: each must be followed by JSON_SCAN().
  * Returns NULL on error (asserts() on bad guide). */
 const char *json_scan(const tal_t *ctx,

--- a/common/jsonrpc_paginator.h
+++ b/common/jsonrpc_paginator.h
@@ -42,6 +42,7 @@
  * @offset: a position (u64) that determines the number of element (in SQL row)
  * returned by request.
  * @limit: a position (u64) that give the number of element in [0,..,offset - 1] to skip skip.
+ * @reverse: a boolean that reverse the order of the result.
  */
 struct jsonrpc_paginator {
 	/** reall usefult for access to gossip map */
@@ -50,6 +51,7 @@ struct jsonrpc_paginator {
 	 * query please use the sql plugins */
 	const u64 *offset;
 	const u64 *limit;
+	const bool *reverse;
 	/* FIXME: more smarter one? like sort_by = "json key"
 	 * but this required to have a mapping between json_keys and sql keys
 	 * maybe we had already somethings in the sql plugin? */
@@ -62,8 +64,9 @@ struct jsonrpc_paginator {
  *
  * BTW: I love C Macros, really!
  */
-static inline struct jsonrpc_paginator *new_paginator(const tal_t *ctx, const char **batch,
-					      const u64 *limit, const u64 *offset)
+static inline struct jsonrpc_paginator *
+new_paginator(const tal_t *ctx, const char **batch, const u64 *limit,
+	      const u64 *offset, const bool *reverse)
 {
 	struct jsonrpc_paginator *paginator = NULL;
 	if (batch || (limit && offset)) {
@@ -71,6 +74,7 @@ static inline struct jsonrpc_paginator *new_paginator(const tal_t *ctx, const ch
 		paginator->batch = batch;
 		paginator->limit = limit;
 		paginator->offset = offset;
+		paginator->reverse = reverse;
 		return paginator;
 	}
 	return NULL;

--- a/common/jsonrpc_paginator.h
+++ b/common/jsonrpc_paginator.h
@@ -2,11 +2,9 @@
  * Welcome in this wanderful experience of writing
  * a paginator for the core lightning JSON RPC 2.0 in C!
  *
- *
  * I will try to keep the code as simple as possible,
  * so if you had any dout on what I'm trying to do, blame me
  * that I was not able to do my job.
- *
  *
  * In short, the goal of this paginator is offer a struct
  * that it is used to grep the paginator information by
@@ -18,16 +16,14 @@
  * if the paginator will be enbaled on the listnodes, the
  * call will be
  *
- * cli | rest | grpc -> json_paginator_listnodes -> json_listnodes + struct jsonrpc_paginator -> sjon response { .... }
+ * cli | rest | grpc -> json_paginator_listnodes -> json_listnodes + struct jsonrpc_paginator -> jon response { .... }
  *
  * Done, this should be all!
- *
- *
- * Now let see how this is implemented.
- * */
+ */
 #ifndef JSONRPC_PAGINATOR_H
 #define JSONRPC_PAGINATOR_H
 
+#include <assert.h>
 #include <ccan/tal/tal.h>
 #include <ccan/short_types/short_types.h>
 
@@ -50,7 +46,8 @@
 struct jsonrpc_paginator {
 	/** reall usefult for access to gossip map */
 	const char **batch;
-	/** query the database */
+	/** query the database, for more complexy
+	 * query please use the sql plugins */
 	const u64 *offset;
 	const u64 *limit;
 	/* FIXME: more smarter one? like sort_by = "json key"
@@ -58,17 +55,18 @@ struct jsonrpc_paginator {
 	 * maybe we had already somethings in the sql plugin? */
 };
 
-/** new_paginator - helper function to create a new paginator from a list of parameter.
+/**
+ * new_paginator - helper function to create a new paginator from a list of parameter.
  * This is simple enought to be avoided, but write simple code inside the C macros
  * is frustating, so let use this insteand.
  *
  * BTW: I love C Macros, really!
- * */
+ */
 static inline struct jsonrpc_paginator *new_paginator(const tal_t *ctx, const char **batch,
 					      const u64 *limit, const u64 *offset)
 {
 	struct jsonrpc_paginator *paginator = NULL;
-	if (batch || limit || offset) {
+	if (batch || (limit && offset)) {
 		paginator = tal(ctx, struct jsonrpc_paginator);
 		paginator->batch = batch;
 		paginator->limit = limit;
@@ -77,5 +75,4 @@ static inline struct jsonrpc_paginator *new_paginator(const tal_t *ctx, const ch
 	}
 	return NULL;
 }
-
 #endif // JSONRPC_PAGINATOR_H

--- a/common/jsonrpc_paginator.h
+++ b/common/jsonrpc_paginator.h
@@ -1,0 +1,81 @@
+/**
+ * Welcome in this wanderful experience of writing
+ * a paginator for the core lightning JSON RPC 2.0 in C!
+ *
+ *
+ * I will try to keep the code as simple as possible,
+ * so if you had any dout on what I'm trying to do, blame me
+ * that I was not able to do my job.
+ *
+ *
+ * In short, the goal of this paginator is offer a struct
+ * that it is used to grep the paginator information by
+ * pre processin the JSON RPC request.
+ *
+ * So let immagine a normal listnode RPC call, where
+ * cli | rest | grpc -> json_listnodes -> json response {....}
+ *
+ * if the paginator will be enbaled on the listnodes, the
+ * call will be
+ *
+ * cli | rest | grpc -> json_paginator_listnodes -> json_listnodes + struct jsonrpc_paginator -> sjon response { .... }
+ *
+ * Done, this should be all!
+ *
+ *
+ * Now let see how this is implemented.
+ * */
+#ifndef JSONRPC_PAGINATOR_H
+#define JSONRPC_PAGINATOR_H
+
+#include <ccan/tal/tal.h>
+#include <ccan/short_types/short_types.h>
+
+/**
+ * jsonrpc_paginator - core struct where all the paginator information
+ * are stored,
+ *
+ * A developer that want to extend the functionality of the
+ * paginator must not abuse of this struct to avoid to made the logic
+ * messy, thanks!
+ *
+ * @batch: array string to be able to query a list of things, useful also
+ * when you deal with reading stuff from file to avoid reaccess to the file
+ * to search another item.
+ *
+ * @offset: a position (u64) that determines the number of element (in SQL row)
+ * returned by request.
+ * @limit: a position (u64) that give the number of element in [0,..,offset - 1] to skip skip.
+ */
+struct jsonrpc_paginator {
+	/** reall usefult for access to gossip map */
+	const char **batch;
+	/** query the database */
+	const u64 *offset;
+	const u64 *limit;
+	/* FIXME: more smarter one? like sort_by = "json key"
+	 * but this required to have a mapping between json_keys and sql keys
+	 * maybe we had already somethings in the sql plugin? */
+};
+
+/** new_paginator - helper function to create a new paginator from a list of parameter.
+ * This is simple enought to be avoided, but write simple code inside the C macros
+ * is frustating, so let use this insteand.
+ *
+ * BTW: I love C Macros, really!
+ * */
+static inline struct jsonrpc_paginator *new_paginator(const tal_t *ctx, const char **batch,
+					      const u64 *limit, const u64 *offset)
+{
+	struct jsonrpc_paginator *paginator = NULL;
+	if (batch || limit || offset) {
+		paginator = tal(ctx, struct jsonrpc_paginator);
+		paginator->batch = batch;
+		paginator->limit = limit;
+		paginator->offset = offset;
+		return paginator;
+	}
+	return NULL;
+}
+
+#endif // JSONRPC_PAGINATOR_H

--- a/common/test/run-json_filter.c
+++ b/common/test/run-json_filter.c
@@ -72,6 +72,8 @@ const char *json_scan(const tal_t *ctx UNNEEDED,
 bool json_to_channel_id(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			struct channel_id *cid UNNEEDED)
 { fprintf(stderr, "json_to_channel_id called!\n"); abort(); }
+bool json_to_strarr(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED, const char ***arr UNNEEDED)
+{ fprintf(stderr, "json_to_strarr called"); abort();}
 /* Generated stub for json_to_millionths */
 bool json_to_millionths(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 			u64 *millionths UNNEEDED)

--- a/common/test/run-json_remove.c
+++ b/common/test/run-json_remove.c
@@ -133,6 +133,9 @@ bool json_to_txid(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 bool json_to_u16(const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
                  uint16_t *num UNNEEDED)
 { fprintf(stderr, "json_to_u16 called!\n"); abort(); }
+bool json_to_strarr(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED,
+		    const jsmntok_t *tok UNNEEDED, const char ***arr UNNEEDED)
+{ fprintf(stderr, "json_to_strarr called"); abort();}
 /* Generated stub for json_tok_bin_from_hex */
 u8 *json_tok_bin_from_hex(const tal_t *ctx UNNEEDED, const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED)
 { fprintf(stderr, "json_tok_bin_from_hex called!\n"); abort(); }

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -45,7 +45,7 @@ struct command {
 	/* Optional output field filter. */
 	struct json_filter *filter;
 	/* Option filtering option */
-	const struct jsonrpc_paginator *paginator;
+	struct jsonrpc_paginator *paginator;
 };
 
 /**

--- a/lightningd/jsonrpc.h
+++ b/lightningd/jsonrpc.h
@@ -1,5 +1,6 @@
 #ifndef LIGHTNING_LIGHTNINGD_JSONRPC_H
 #define LIGHTNING_LIGHTNINGD_JSONRPC_H
+#include "ccan/compiler/compiler.h"
 #include "config.h"
 #include <ccan/list/list.h>
 #include <common/autodata.h>
@@ -17,6 +18,10 @@ enum command_mode {
 	/* Check parameters, nothing else. */
 	CMD_CHECK
 };
+
+// FIXME(vincenzopalazzo): The filtering architecture
+// desearve an own file.
+struct jsonrpc_paginator { };
 
 /* Context for a command (from JSON, but might outlive the connection!). */
 /* FIXME: move definition into jsonrpc.c */
@@ -43,6 +48,8 @@ struct command {
 	struct json_stream *json_stream;
 	/* Optional output field filter. */
 	struct json_filter *filter;
+	/* Option filtering option */
+	struct jsonrpc_paginator *paginator;
 };
 
 /**
@@ -223,6 +230,7 @@ struct jsonrpc_notification *jsonrpc_notification_start(const tal_t *ctx, const 
  */
 void jsonrpc_notification_end(struct jsonrpc_notification *n);
 
+
 /**
  * start a JSONRPC request; id_prefix is non-NULL if this was triggered by
  * another JSONRPC request.
@@ -270,6 +278,15 @@ struct jsonrpc_request *jsonrpc_request_start_(
     void *response_cb_arg);
 
 void jsonrpc_request_end(struct jsonrpc_request *request);
+
+#define PAGINATOR(callback)                                                             \
+	static struct command_result *callback##_paginator(struct command *cmd,       \
+	                                     const char *buffer,                        \
+	                                     const jsmntok_t *obj UNNEEDED,             \
+	                                     const jsmntok_t *params)                   \
+	{                                                                               \
+	   return callback(cmd, buffer, obj, params);                                   \
+        }
 
 AUTODATA_TYPE(json_command, struct json_command);
 

--- a/lightningd/peer_htlcs.c
+++ b/lightningd/peer_htlcs.c
@@ -2927,15 +2927,16 @@ void json_add_forwarding_object(struct json_stream *response,
 	json_object_end(response);
 }
 
-static void listforwardings_add_forwardings(struct json_stream *response,
-					    struct wallet *wallet,
+static void listforwardings_add_forwardings(struct command *cmd,
+					    struct json_stream *response,
 					    enum forward_status status,
 					    const struct short_channel_id *chan_in,
 					    const struct short_channel_id *chan_out)
 {
 	const struct forwarding *forwardings;
 
-	forwardings = wallet_forwarded_payments_get(wallet, tmpctx, status, chan_in, chan_out);
+	forwardings = wallet_forwarded_payments_get(cmd->ld->wallet, tmpctx, status,
+						    chan_in, chan_out, cmd->paginator);
 
 	json_array_start(response, "forwards");
 	for (size_t i=0; i<tal_count(forwardings); i++) {
@@ -2978,11 +2979,12 @@ static struct command_result *json_listforwards(struct command *cmd,
 			     FORWARD_ANY),
 		   p_opt("in_channel", param_short_channel_id, &chan_in),
 		   p_opt("out_channel", param_short_channel_id, &chan_out),
+		   p_paginator(&cmd->paginator),
 		   NULL))
 		return command_param_failed();
 
 	response = json_stream_success(cmd);
-	listforwardings_add_forwardings(response, cmd->ld->wallet, *status, chan_in, chan_out);
+	listforwardings_add_forwardings(cmd, response, *status, chan_in, chan_out);
 
 	return command_success(cmd, response);
 }

--- a/plugins/libplugin.h
+++ b/plugins/libplugin.h
@@ -487,23 +487,4 @@ const jsmntok_t *jsonrpc_request_sync(const tal_t *ctx, struct plugin *plugin,
 				      const char *method,
 				      const struct json_out *params TAKES,
 				      const char **resp);
-
-#define PAGINATOR(callback)						                \
-	static struct command_result* callback##_paginator(struct command *cmd,         \
-	                                     const char *buffer,                        \
-	                                     const jsmntok_t *params)                   \
-	{                                                                               \
-		const char **batch;						        \
-		u64 *limit, *offset;                                                    \
-                if (!param(cmd, buffer, params,				                \
-	             p_opt("batch", param_arr_str, &batch),                             \
-                     p_opt("limit", param_u64, &limit),                                 \
-		     p_opt("offset", param_u64, &offset),                               \
-	             p_opt_any(),                                                       \
-		     NULL))                                                             \
-		     return command_param_failed();                                     \
-		cmd->paginator = new_paginator(cmd, batch, limit, offset);              \
-                return callback(cmd, buffer, params);				        \
-        }
-
 #endif /* LIGHTNING_PLUGINS_LIBPLUGIN_H */

--- a/plugins/topology.c
+++ b/plugins/topology.c
@@ -1,7 +1,3 @@
-#include "ccan/list/list.h"
-#include "ccan/strmap/strmap.h"
-#include "ccan/tal/tal.h"
-#include "common/node_id.h"
 #include "config.h"
 #include <assert.h>
 #include <ccan/array_size/array_size.h>
@@ -431,13 +427,13 @@ static bool node_in_paginator(struct command *cmd, struct node_id *node_id)
 			for (i = 0; i < tal_count(p->batch); i++) {
 				id = p->batch[i];
 				if (strcmp(id, target_id) == 0)
-					return true;
+					goto done;
 				plugin_log(cmd->plugin, LOG_DBG, "not match %s != %s", target_id, id);
 			}
 		}
 		return false;
 	}
-	tal_free(p);
+done:
 	return true;
 }
 
@@ -525,7 +521,7 @@ static struct command_result *json_listnodes(struct command *cmd,
 
 	if (!param(cmd, buffer, params,
 		   p_opt("id", param_node_id, &id),
-		   p_paginator(),
+		   p_paginator(&cmd->paginator),
 		   NULL))
 		return command_param_failed();
 
@@ -670,8 +666,6 @@ static const char *init(struct plugin *p,
 	return NULL;
 }
 
-PAGINATOR(json_listnodes);
-
 static const struct plugin_command commands[] = {
 	{
 		"getroute",
@@ -698,7 +692,7 @@ static const struct plugin_command commands[] = {
 		"network",
 		"List all known nodes in the network",
 		"Show node {id} (or all known nods, if not specified)",
-		json_listnodes_paginator,
+		json_listnodes,
 	},
 	{
 		"listincoming",

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -1,0 +1,21 @@
+"""
+I think I'm getting to excited for this paginator API
+that I think this deserve a own python test file!
+"""
+from fixtures import * # noqua: F401,F403
+
+
+def test_listnodes_paginator(node_factory):
+    """
+    We run 4 nodes and then we query the
+    list node by batch for the other two nodes.
+    """
+    l1, l2, l3, _ = node_factory.line_graph(4, fundchannel=True, wait_for_announce=True)
+    l1.rpc.jsonschemas = {}
+
+    nodes = l1.rpc.call("listnodes", { "batch": [l3.info["id"], l2.info["id"]] })
+    nodes_nobatch = l1.rpc.listnodes()
+    print(nodes)
+    print(nodes_nobatch)
+    assert len(nodes["nodes"]) == 2
+    assert len(nodes_nobatch["nodes"]) == 4

--- a/tests/test_paginator.py
+++ b/tests/test_paginator.py
@@ -2,8 +2,9 @@
 I think I'm getting to excited for this paginator API
 that I think this deserve a own python test file!
 """
+import unittest
 from fixtures import * # noqua: F401,F403
-
+from utils import COMPAT
 
 def test_listnodes_paginator(node_factory):
     """
@@ -13,9 +14,28 @@ def test_listnodes_paginator(node_factory):
     l1, l2, l3, _ = node_factory.line_graph(4, fundchannel=True, wait_for_announce=True)
     l1.rpc.jsonschemas = {}
 
-    nodes = l1.rpc.call("listnodes", { "batch": [l3.info["id"], l2.info["id"]] })
+    nodes = l1.rpc.call("listnodes", { "paginator": { "batch": [l3.info["id"], l2.info["id"]] } })
     nodes_nobatch = l1.rpc.listnodes()
     print(nodes)
     print(nodes_nobatch)
     assert len(nodes["nodes"]) == 2
     assert len(nodes_nobatch["nodes"]) == 4
+
+
+@unittest.skipIf(os.getenv('TEST_DB_PROVIDER', 'sqlite3') != 'sqlite3', "Canned db used")
+@unittest.skipIf(not COMPAT, "needs COMPAT to convert obsolete db")
+@unittest.skipIf(TEST_NETWORK != 'regtest', "The DB migration is network specific due to the chain var.")
+def test_filter_listforwards_from_db(bitcoind, node_factory):
+    """This test is taken from the test_db and adapt to support the
+    paginator API. This allow to have a static way to assert over the
+    forwards without doing crazy things."""
+    bitcoind.generate_block(113)
+    l1 = node_factory.get_node(dbfile='v0.12.1-forward.sqlite3.xz',
+                               options={'database-upgrade': True})
+
+    assert l1.rpc.getinfo()['fees_collected_msat'] == 4
+    assert len(l1.rpc.listforwards()['forwards']) == 4
+    filter_forwards = l1.rpc.call("listforwards", { "paginator": { "limit": 2, "offset": 0 } })['forwards']
+    assert len(filter_forwards) == 2
+
+

--- a/wallet/test/run-wallet.c
+++ b/wallet/test/run-wallet.c
@@ -1,6 +1,5 @@
 #include "config.h"
-  #include <lightningd/log.h>
-
+#include <lightningd/log.h>
 #include "test_utils.h"
 #include <ccan/tal/str/str.h>
 #include <db/common.h>
@@ -617,7 +616,11 @@ struct command_result *param_bool(struct command *cmd UNNEEDED, const char *name
 				  const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
 				  bool **b UNNEEDED)
 { fprintf(stderr, "param_bool called!\n"); abort(); }
-/* Generated stub for param_channel_id */
+/* Generated stub for param_bool */
+struct command_result *param_paginator(struct command *cmd UNNEEDED, const char *name UNNEEDED,
+				  const char *buffer UNNEEDED, const jsmntok_t *tok UNNEEDED,
+				  struct jsonrpc_paginator **b UNNEEDED)
+{ fprintf(stderr, "param_paginator called!\n"); abort(); }/* Generated stub for param_channel_id */
 struct command_result *param_channel_id(struct command *cmd UNNEEDED,
 					const char *name UNNEEDED,
 					const char *buffer UNNEEDED,

--- a/wallet/wallet.h
+++ b/wallet/wallet.h
@@ -6,6 +6,7 @@
 #include <common/onion_encode.h>
 #include <common/penalty_base.h>
 #include <common/utxo.h>
+#include <common/jsonrpc_paginator.h>
 #include <common/wallet.h>
 #include <lightningd/bitcoind.h>
 #include <lightningd/log.h>
@@ -1359,7 +1360,8 @@ const struct forwarding *wallet_forwarded_payments_get(struct wallet *w,
 						       const tal_t *ctx,
 						       enum forward_status state,
 						       const struct short_channel_id *chan_in,
-						       const struct short_channel_id *chan_out);
+						       const struct short_channel_id *chan_out,
+	                                               const struct jsonrpc_paginator *paginator);
 
 /**
  * Delete a particular forward entry


### PR DESCRIPTION
Since we don't fetch the full database anymore, we need a way to paginate through the data in reverse order. I've implemented a flag to the paginator argument.

When I run the code it crashes at https://github.com/vincenzopalazzo/lightning/blob/41aae430e141a363c7c8adf86344ee833194c1bf/db/bindings.c#L41

Any idea why?